### PR TITLE
fix: add "be" in definition of tangent vector

### DIFF
--- a/2-tangentbdl.tex
+++ b/2-tangentbdl.tex
@@ -161,7 +161,7 @@ We can now go back to our discussion of euclidean derivations to motivate our de
 Motivated by Example~\ref{ex:euclideanD}, we define a tangent vector as a derivation on the space of germs.
 
 \begin{definition}
-  Let $M$ a smooth manifold of dimension $n$ and let $p\in M$.
+  Let $M$ be a smooth manifold of dimension $n$ and let $p\in M$.
   A \emph{tangent vector at $p$} is a linear map
   \marginnote{Keep always in mind that the value $v([f]_p)$ only depends on the value of $f$ around the point $p$.}
   \begin{equation}\label{def:tangentvector}


### PR DESCRIPTION
Corrects a missing "be" in the definition of tangent vector at a point